### PR TITLE
FRENCH translation for the Topic Author extension + Two fixs

### DIFF
--- a/adm/style/acp_topicauthor_config.html
+++ b/adm/style/acp_topicauthor_config.html
@@ -33,7 +33,7 @@
 				<span>{L_TOPICAUTHOR_TEXT_FIELD_EXPLAIN}</span>
 			</dt>
 			<dd>
-				<input name="topicauthor_text_field" type="text" id="topicauthor_text_field" class="inputbox autowidth" value="{TOPICAUTHOR_TEXT_FIELD}" maxlength="10" />
+				<input name="topicauthor_text_field" type="text" id="topicauthor_text_field" class="inputbox autowidth" value="{TOPICAUTHOR_TEXT_FIELD}" maxlength="100" />
 			</dd>
 		</dl>
 		<dl>

--- a/language/fr/acp_topicauthor.php
+++ b/language/fr/acp_topicauthor.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ *
+ * Topic Author. An extension for the phpBB Forum Software package.
+ * French translation by Galixte (http://www.galixte.com)
+ *
+ * @copyright (c) 2018 dmzx <https://www.dmzx-web.net>
+ * @license GNU General Public License, version 2 (GPL-2.0-only)
+ *
+ */
+
+/**
+ * DO NOT CHANGE
+ */
+if (!defined('IN_PHPBB'))
+{
+	exit;
+}
+
+if (empty($lang) || !is_array($lang))
+{
+	$lang = array();
+}
+
+// DEVELOPERS PLEASE NOTE
+//
+// All language files should use UTF-8 as their encoding and the files must not contain a BOM.
+//
+// Placeholders can now contain order information, e.g. instead of
+// 'Page %s of %s' you can (and should) write 'Page %1$s of %2$s', this allows
+// translators to re-order the output of data while ensuring it remains correct
+//
+// You do not need this where single placeholders are used, e.g. 'Message %d' is fine
+// equally where a string contains only two placeholders which are used to wrap text
+// in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
+//
+// Some characters you may want to copy&paste:
+// ’ « » “ ” …
+//
+
+$lang = array_merge($lang, array(
+	'TOPICAUTHOR_CONFIG_SAVED'				=> 'Les paramètres ont été sauvergardés avec succès !',
+	'TOPICAUTHOR_VERSION'					=> 'Version de l’extension',
+	'TOPICAUTHOR_ENABLE'					=> 'Activer l’affichage de l’indicateur « Auteur du sujet »',
+	'TOPICAUTHOR_ENABLE_EXPLAIN'			=> 'Permet d’activer l’affichage de l’indicateur « Auteur du sujet » sur la page de la vue du sujet.',
+	'TOPICAUTHOR_COLOUR_FIELD'				=> 'Sélectionner la couleur de l’indicateur « Auteur du sujet »',
+	'TOPICAUTHOR_COLOUR_FIELD_EXPLAIN'		=> 'Permet de sélectionner la couleur de l’indicateur « Auteur du sujet » au moyen du sélecteur de couleurs ci-contre.',
+	'TOPICAUTHOR_TEXT_FIELD'				=> 'Saisir le texte de l’indicateur « Auteur du sujet »',
+	'TOPICAUTHOR_TEXT_FIELD_EXPLAIN'		=> 'Permet de saisir le texte affiché comme indicateur « Auteur du sujet ».',
+	'TOPICAUTHOR_TEXT_COLOUR_FIELD'			=> 'Sélectionner la couleur du texte de l’indicateur « Auteur du sujet »',
+	'TOPICAUTHOR_TEXT_COLOUR_FIELD_EXPLAIN'	=> 'Permet de sélectionner la couleur du texte affiché dans l’indicateur « Auteur du sujet » au moyen du sélecteur de couleurs ci-contre.',
+));

--- a/language/fr/info_acp_topicauthor.php
+++ b/language/fr/info_acp_topicauthor.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *
+ * Topic Author. An extension for the phpBB Forum Software package.
+ * French translation by Galixte (http://www.galixte.com)
+ *
+ * @copyright (c) 2018 dmzx <https://www.dmzx-web.net>
+ * @license GNU General Public License, version 2 (GPL-2.0-only)
+ *
+ */
+
+/**
+ * DO NOT CHANGE
+ */
+if (!defined('IN_PHPBB'))
+{
+	exit;
+}
+
+if (empty($lang) || !is_array($lang))
+{
+	$lang = array();
+}
+
+// DEVELOPERS PLEASE NOTE
+//
+// All language files should use UTF-8 as their encoding and the files must not contain a BOM.
+//
+// Placeholders can now contain order information, e.g. instead of
+// 'Page %s of %s' you can (and should) write 'Page %1$s of %2$s', this allows
+// translators to re-order the output of data while ensuring it remains correct
+//
+// You do not need this where single placeholders are used, e.g. 'Message %d' is fine
+// equally where a string contains only two placeholders which are used to wrap text
+// in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
+//
+// Some characters you may want to copy&paste:
+// ’ « » “ ” …
+//
+
+$lang = array_merge($lang, array(
+	'ACP_TOPICAUTHOR'						=> 'Auteur du sujet',
+	'ACP_TOPICAUTHOR_CONFIG_SETTINGS'		=> 'Paramètres',
+	'ACP_TOPICAUTHOR_CONFIG_SET'			=> 'Configuration',
+	//Log
+	'LOG_TOPICAUTHOR_SAVED'					=> '<strong>Configuration de l’outil « Auteur du sujet » mise à jour</strong>',
+));

--- a/styles/all/theme/topicauthor.css
+++ b/styles/all/theme/topicauthor.css
@@ -15,7 +15,6 @@
     font-size: 9px;
     font-weight: bold;
     background-repeat: repeat-x;
-	text-transform: capitalize;
 }
     
 @media (max-width: 700px) {


### PR DESCRIPTION
Hi @dmzx,

could you merge this, please?

- The field “Topic Author” for to enter the text is limited to 10 characters so it’s to short for FRENCH language by example,
- The CSS rule ```text-transform: capitalize;``` isn’t adapted to FRENCH language because we don’t use an upper-case at the beginning of each word.